### PR TITLE
Add dragonstorm maptimer

### DIFF
--- a/maptimer.xml
+++ b/maptimer.xml
@@ -231,4 +231,8 @@
     <Event Name="Raven Shrines" Length="10" Color="8065b0e8"/>
     <Event Name="Shards and Construct" Length="10" Color="804199d8"/>
   </Map>
+  <Map Name="Dragonstorm" Length="120" Start="60" id="s5e5ds">
+    <Event Name="Dragonstorm" Length="20" Color="8079afff"/>
+    <Event Name="" Length="100" Color="00000000"/>
+  </Map>
 </GW2MapTimer>


### PR DESCRIPTION
## Description
This adds Dragonstorm to the maptimer. The Solution was made by @Dinichou 

## Related issue
Fixes #4 

## How can this be tested?
Build TacO and start it with gw2. If you have the maptimer window active you can see the new Dragonstorm meta.