### PR TITLE
Fix file resolution issue with Metal Marker Myriad

### DIFF
--- a/MarkerPacks.json
+++ b/MarkerPacks.json
@@ -80,7 +80,7 @@
       "versionurl": "https://github.com/Metallis/Metal-Marker-Myriad/releases/latest",
       "versionsearchstring": "releases/tag/",
       "versionterminator": "\"",
-      "downloadurl": "https://github.com/Metallis/Metal-Marker-Myriad/releases/latest/download/Metal_Marker_Myriad.taco",
+      "downloadurl": "https://github.com/Metallis/Metal-Marker-Myriad/releases/latest/download/Metal.Marker.Myriad.taco",
       "enabledbydefault": false
     },
     {


### PR DESCRIPTION
I don't know if this affects Taco, but I assume it does. The Metal Marker Myriad pack's release file is called `Metal.Marker.Myriad.taco`. Since the file includes `.` the URL redirects to https://github.com/Metallis/Metal-Marker-Myriad/releases/download/v5.0/Metal_Marker_Myriad.taco. However, directly navigating to that URL results in a 404. In order to access the file you have to access the `.` delimited filename. 

I have opened this as an issue on their repo. Since I updated the URLs & didn't properly test I apologize, but it's possible this has been broken before my changes.